### PR TITLE
Update to Oxygen Release. Fix typo in Oxygen package list.

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -60,8 +60,8 @@ eclipse_defaults:
       packages: [jee,java,cpp,android,php,committers,modeling,reporting,rcp,testing,parallel,scout]
     oxygen:
       version: 4.7
-      latest_service_release: M6
-      packages: [jee,java,cpp,android,committers,javascript,dsl,testing,rcp,parallel,mdoeling,scout]
+      latest_service_release: R
+      packages: [jee,java,cpp,android,committers,javascript,dsl,testing,rcp,parallel,modeling,scout]
   plugins:
     aptana_studio:
       repositories:


### PR DESCRIPTION
Noticed a couple typos in the 'oxygen' release properties.